### PR TITLE
Updated IMU Message to not Overflow

### DIFF
--- a/can-messages/vcu.json
+++ b/can-messages/vcu.json
@@ -2212,7 +2212,7 @@
         "endianness": "big",
         "formatter": {
           "key": "divide",
-          "arg": 20
+          "arg": 4
         },
         "sim": {
           "min": 0,
@@ -2230,7 +2230,7 @@
         "endianness": "big",
         "formatter": {
           "key": "divide",
-          "arg": 20
+          "arg": 4
         },
         "sim": {
           "min": 0,
@@ -2243,12 +2243,12 @@
         "name": "imu_accelerometer_y"
       },
       {
-        "size": 32,
+        "size": 16,
         "signed": true,
         "endianness": "big",
         "formatter": {
           "key": "divide",
-          "arg": 20
+          "arg": 4
         },
         "sim": {
           "min": 0,
@@ -2829,5 +2829,95 @@
       }
     ],
     "sim_freq": 250
+  },
+  {
+    "id": "0xBAD",
+    "desc": "VCU Test Message",
+    "points": [
+      {
+        "size": 3,
+        "signed": false,
+        "name": "three_bits",
+        "c_type": "uint8_t"
+      },
+      {
+        "size": 32,
+        "signed": true,
+        "c_type": "float",
+        "name": "float_value",
+        "endianness": "big",
+        "formatter": {
+          "key": "divide",
+          "arg": 100
+        }
+      },
+      {
+        "size": 5,
+        "signed": false,
+        "name": "five_bits",
+        "c_type": "uint8_t"
+      },
+      {
+        "size": 16,
+        "signed": false,
+        "name": "sixteen_bits",
+        "c_type": "uint16_t",
+        "endianness": "big"
+      },
+      {
+        "size": 8,
+        "signed": true,
+        "name": "signed_8_bits",
+        "c_type": "int8_t"
+      }
+    ],
+    "fields": [
+      {
+        "name": "three_bits",
+        "unit": "",
+        "values": [
+          1
+        ],
+        "doc": "",
+        "desc": ""
+      },
+      {
+        "name": "float_value",
+        "unit": "",
+        "values": [
+          2
+        ],
+        "doc": "",
+        "desc": ""
+      },
+      {
+        "name": "five_bits",
+        "unit": "",
+        "values": [
+          3
+        ],
+        "doc": "",
+        "desc": ""
+      },
+      {
+        "name": "sixteen_bits",
+        "unit": "",
+        "values": [
+          4
+        ],
+        "doc": "",
+        "desc": ""
+      },
+      {
+        "name": "signed_8_bits",
+        "unit": "",
+        "values": [
+          5
+        ],
+        "doc": "",
+        "desc": ""
+      }
+    ],
+    "is_ext": true
   }
 ]


### PR DESCRIPTION
IMU message kept overflowing in Cerberus-2.0, so I increased the sizes of each field and lowered the scaling.