### PR TITLE
Drive Locks

### DIFF
--- a/can-messages/vcu.json
+++ b/can-messages/vcu.json
@@ -2516,7 +2516,7 @@
       },
       {
         "size": 16,
-        "signed": false,
+        "signed": true,
         "name": "brake_psi",
         "c_type": "float",
         "formatter": {
@@ -2527,7 +2527,8 @@
           "min": 0,
           "max": 5000,
           "inc_min": 0.1,
-          "inc_max": 500
+          "inc_max": 500,
+          "round": false
         }
       }
     ],

--- a/can-messages/vcu.json
+++ b/can-messages/vcu.json
@@ -4092,5 +4092,182 @@
         "desc": ""
       }
     ]
+  },
+  {
+    "id": "0x503",
+    "desc": "Drive Lock States",
+    "points": [
+      {
+        "size": 1,
+        "signed": false,
+        "name": "BRAKE_OC",
+        "c_type": "bool",
+        "sim": {
+          "options": [
+            [
+              0,
+              0.5
+            ],
+            [
+              1,
+              0.5
+            ]
+          ]
+        }
+      },
+      {
+        "size": 1,
+        "signed": false,
+        "name": "BRAKE_SC",
+        "c_type": "bool",
+        "sim": {
+          "options": [
+            [
+              0,
+              0.5
+            ],
+            [
+              1,
+              0.5
+            ]
+          ]
+        }
+      },
+      {
+        "size": 1,
+        "signed": false,
+        "name": "ACCEL_OC",
+        "c_type": "bool",
+        "sim": {
+          "options": [
+            [
+              0,
+              0.5
+            ],
+            [
+              1,
+              0.5
+            ]
+          ]
+        }
+      },
+      {
+        "size": 1,
+        "signed": false,
+        "name": "ACCEL_SC",
+        "c_type": "bool",
+        "sim": {
+          "options": [
+            [
+              0,
+              0.5
+            ],
+            [
+              1,
+              0.5
+            ]
+          ]
+        }
+      },
+      {
+        "size": 1,
+        "signed": false,
+        "name": "ACCEL_DIFF",
+        "c_type": "bool",
+        "sim": {
+          "options": [
+            [
+              0,
+              0.5
+            ],
+            [
+              1,
+              0.5
+            ]
+          ]
+        }
+      },
+      {
+        "size": 1,
+        "signed": false,
+        "name": "BSPD_PREF",
+        "c_type": "bool",
+        "sim": {
+          "options": [
+            [
+              0,
+              0.5
+            ],
+            [
+              1,
+              0.5
+            ]
+          ]
+        }
+      },
+      {
+        "size": 2,
+        "signed": false,
+        "name": "empty",
+        "parse": false
+      }
+    ],
+    "fields": [
+      {
+        "name": "VCU/Pedals/Drive_Locks/BRAKE_OC",
+        "unit": "",
+        "values": [
+          1
+        ],
+        "doc": "",
+        "desc": ""
+      },
+      {
+        "name": "VCU/Pedals/Drive_Locks/BRAKE_SC",
+        "unit": "",
+        "values": [
+          2
+        ],
+        "doc": "",
+        "desc": ""
+      },
+      {
+        "name": "VCU/Pedals/Drive_Locks/ACCEL_OC",
+        "unit": "",
+        "values": [
+          3
+        ],
+        "doc": "",
+        "desc": ""
+      },
+      {
+        "name": "VCU/Pedals/Drive_Locks/ACCEL_SC",
+        "unit": "",
+        "values": [
+          4
+        ],
+        "doc": "",
+        "desc": ""
+      },
+      {
+        "name": "VCU/Pedals/Drive_Locks/ACCEL_DIFF",
+        "unit": "",
+        "values": [
+          5
+        ],
+        "doc": "",
+        "desc": ""
+      },
+      {
+        "name": "VCU/Pedals/Drive_Locks/BSPD_PREF",
+        "unit": "",
+        "values": [
+          6
+        ],
+        "doc": "",
+        "desc": ""
+      }
+    ],
+    "sim_freq": 250
   }
 ]

--- a/code-gen/templates/encoders.c.j2
+++ b/code-gen/templates/encoders.c.j2
@@ -18,7 +18,7 @@ static void handle_bitstream_overflow(bitstream_t *bitstream_res,
 {% for msg in can_msgs -%}
 uint8_t send_{{ macros.function_name(msg) }}
 (
-    {%- for point in msg.points if point.name is defined -%}
+    {%- for point in msg.points if point.name is defined and (point.parse is not defined or point.parse is not false) -%}
     {{ point.c_type }} {{ point.name -}}
     {{- "," if not loop.last -}}
     {%- endfor -%}
@@ -57,6 +57,7 @@ uint8_t send_{{ macros.function_name(msg) }}
         {%- for point in msg.points %}
             {%- if point.name is defined %}
                 {%- set shift = total_bits - bit_pos.value - point.size %}
+                {%- if point.parse is not defined or point.parse is not false %}
                     {%- if point.signed is defined and point.signed %}
                         {#- Handle signed points! -#}
                         {%- set max_value = (2 ** (point.size - 1)) - 1 %}
@@ -80,6 +81,7 @@ uint8_t send_{{ macros.function_name(msg) }}
                         }
                         data |= (({{ point.name }}_i) & 0x{{ '%X' | format((2 ** point.size) - 1) }}ULL) << {{ shift }};
                     {%- endif %}
+                {%- endif %}
                     {%- set bit_pos.value = bit_pos.value + point.size %}
             {% endif %}
         {%- endfor %}
@@ -103,10 +105,14 @@ uint8_t send_{{ macros.function_name(msg) }}
         {% endfor %}
     } bitstream_data;
     {% for point in msg.points -%}
+    {%- if point.parse is not defined or point.parse is not false %}
     bitstream_data.{{ point.name }} = ({{ macros.c_int_type(point.size, point.signed) }})({{ point.name }}{{ macros.point_scalar(point) }});
         {% if point.endianness is defined and point.endianness == "big" %}
     endian_swap(&bitstream_data.{{ point.name -}}, sizeof(bitstream_data.{{ point.name -}}));
         {%- endif %}
+    {%- else %}
+    bitstream_data.{{ point.name }} = 0;
+    {%- endif %}
     {%- endfor %}
     memcpy(msg.data, &bitstream_data, sizeof(bitstream_data));
     {%- endif %}

--- a/code-gen/templates/encoders.h.j2
+++ b/code-gen/templates/encoders.h.j2
@@ -23,7 +23,7 @@
 */
 uint8_t send_{{ macros.function_name(msg) }}
 (
-    {%- for point in msg.points if point.name is defined -%}
+    {%- for point in msg.points if point.name is defined and (point.parse is not defined or point.parse is not false) -%}
     {{ point.c_type }} {{ point.name -}}
     {{- "," if not loop.last -}}
     {%- endfor -%}


### PR DESCRIPTION
New message for drive locks.

Also, added some small codegen changes to ignore points with `parse = false`. The message structures are unchanged, the non-parse points just aren't exposed as parameters and are auto-filled with zeros under the hood.