### PR TITLE
Lightning Pulse Message

### DIFF
--- a/can-messages/lightning.json
+++ b/can-messages/lightning.json
@@ -268,5 +268,30 @@
       }
     ],
     "sim_freq": 1000
+  },
+  {
+    "id": "0xAAE",
+    "desc": "Lightning Pulse Message",
+    "points": [
+      {
+        "size": 32,
+        "signed": false,
+        "name": "count",
+        "c_type": "uint32_t",
+        "endianness": "big"
+      }
+    ],
+    "fields": [
+      {
+        "name": "Lightning/Pulse/Count",
+        "unit": "",
+        "values": [
+          1
+        ],
+        "doc": "Number of times the lightning pulse has been sent.",
+        "desc": ""
+      }
+    ],
+    "is_ext": true
   }
 ]


### PR DESCRIPTION
New "pulse" message to be sent over CAN by Lightning. This ensures that, if the lightning sensor and IMU messages fail for whatever reason, VCU still receives a pulse confirming that communication with Lightning is still live.