### PR TITLE
Add BMS HIL calypso test mode message

### DIFF
--- a/can-messages/calypso_cmd.json
+++ b/can-messages/calypso_cmd.json
@@ -581,7 +581,7 @@
   },
   {
     "id": "0x451",
-    "desc": "Shepherd BMS Alpha Emulated Cell Data",
+    "desc": "Shepherd BMS Emulated Alpha Cell Data",
     "points": [
       {
         "size": 10,
@@ -680,7 +680,7 @@
     ],
     "fields": [
       {
-        "name": "Calypso/Bidir/State/BMSAlphaEmulatedCellData/{4}/Therms/{5}",
+        "name": "Calypso/Bidir/State/BMSEmulatedAlphaCellData/{4}/Therms/{5}",
         "unit": "C",
         "values": [
           1
@@ -688,7 +688,7 @@
         "doc": "Current emulated thermistor temperature"
       },
       {
-        "name": "Calypso/Bidir/State/BMSAlphaEmulatedCellData/{4}/Volts/{5}",
+        "name": "Calypso/Bidir/State/BMSEmulatedAlphaCellData/{4}/Volts/{5}",
         "unit": "V",
         "values": [
           2
@@ -696,7 +696,7 @@
         "doc": "Current emulated cell voltage"
       },
       {
-        "name": "Calypso/Bidir/State/BMSAlphaEmulatedCellData/{4}/Volts/{6}",
+        "name": "Calypso/Bidir/State/BMSEmulatedAlphaCellData/{4}/Volts/{6}",
         "unit": "V",
         "values": [
           3
@@ -704,13 +704,13 @@
         "doc": "Current emulated cell voltage"
       }
     ],
-    "key": "BMSAlphaEmulatedCellData",
+    "key": "BMSEmulatedAlphaCellData",
     "bidir_mode": "broadcast",
     "sim_freq": 500
   },
   {
     "id": "0x452",
-    "desc": "Shepherd BMS Beta Emulated Cell Data",
+    "desc": "Shepherd BMS Emulated Beta Cell Data",
     "points": [
       {
         "size": 10,
@@ -809,7 +809,7 @@
     ],
     "fields": [
       {
-        "name": "Calypso/Bidir/State/BMSBetaEmulatedCellData/{4}/Therms/{5}",
+        "name": "Calypso/Bidir/State/BMSEmulatedBetaCellData/{4}/Therms/{5}",
         "unit": "C",
         "values": [
           1
@@ -817,7 +817,7 @@
         "doc": "Current emulated thermistor temperature"
       },
       {
-        "name": "Calypso/Bidir/State/BMSBetaEmulatedCellData/{4}/Volts/{5}",
+        "name": "Calypso/Bidir/State/BMSEmulatedBetaCellData/{4}/Volts/{5}",
         "unit": "V",
         "values": [
           2
@@ -825,7 +825,7 @@
         "doc": "Current emulated cell voltage"
       },
       {
-        "name": "Calypso/Bidir/State/BMSBetaEmulatedCellData/{4}/Volts/{6}",
+        "name": "Calypso/Bidir/State/BMSEmulatedBetaCellData/{4}/Volts/{6}",
         "unit": "V",
         "values": [
           3
@@ -833,7 +833,7 @@
         "doc": "Current emulated cell voltage"
       }
     ],
-    "key": "BMSBetaEmulatedCellData",
+    "key": "BMSEmulatedBetaCellData",
     "bidir_mode": "broadcast",
     "sim_freq": 500
   }

--- a/can-messages/calypso_cmd.json
+++ b/can-messages/calypso_cmd.json
@@ -653,9 +653,9 @@
         "c_type": "uint8_t",
         "sim": {
           "min": 0,
-          "max": 6,
-          "inc_min": 1,
-          "inc_max": 1,
+          "max": 12,
+          "inc_min": 2,
+          "inc_max": 2,
           "round": true
         }
       },
@@ -665,10 +665,10 @@
         "name": "cell_b",
         "c_type": "uint8_t",
         "sim": {
-          "min": 0,
+          "min": 1,
           "max": 13,
-          "inc_min": 1,
-          "inc_max": 1,
+          "inc_min": 2,
+          "inc_max": 2,
           "round": true
         }
       },
@@ -782,9 +782,9 @@
         "c_type": "uint8_t",
         "sim": {
           "min": 0,
-          "max": 5,
-          "inc_min": 1,
-          "inc_max": 1,
+          "max": 12,
+          "inc_min": 2,
+          "inc_max": 2,
           "round": true
         }
       },
@@ -794,10 +794,10 @@
         "name": "cell_b",
         "c_type": "uint8_t",
         "sim": {
-          "min": 0,
-          "max": 10,
-          "inc_min": 1,
-          "inc_max": 1,
+          "min": 1,
+          "max": 13,
+          "inc_min": 2,
+          "inc_max": 2,
           "round": true
         }
       },

--- a/can-messages/calypso_cmd.json
+++ b/can-messages/calypso_cmd.json
@@ -578,5 +578,263 @@
     "key": "RTDSCommand",
     "sim_freq": 7500,
     "bidir_mode": "oneshot"
+  },
+  {
+    "id": "0x456",
+    "desc": "Shepherd BMS Alpha Emulated Cell Data",
+    "points": [
+      {
+        "size": 10,
+        "signed": false,
+        "name": "therm",
+        "c_type": "float",
+        "formatter": {
+          "key": "divide",
+          "arg": 10
+        },
+        "sim": {
+          "min": 20,
+          "max": 80,
+          "inc_min": 0.01,
+          "inc_max": 0.5,
+          "round": false
+        }
+      },
+      {
+        "size": 13,
+        "signed": false,
+        "name": "voltage_a",
+        "c_type": "float",
+        "formatter": {
+          "key": "divide",
+          "arg": 1000
+        },
+        "sim": {
+          "min": 2.5,
+          "max": 4.25,
+          "inc_min": 0.01,
+          "inc_max": 0.2,
+          "round": false
+        }
+      },
+      {
+        "size": 13,
+        "signed": false,
+        "name": "voltage_b",
+        "c_type": "float",
+        "formatter": {
+          "key": "divide",
+          "arg": 1000
+        },
+        "sim": {
+          "min": 2.5,
+          "max": 4.25,
+          "inc_min": 0.01,
+          "inc_max": 0.2
+        }
+      },
+      {
+        "size": 4,
+        "signed": false,
+        "name": "chip_id",
+        "c_type": "uint8_t",
+        "sim": {
+          "min": 0,
+          "max": 4,
+          "inc_min": 1,
+          "inc_max": 1,
+          "round": true
+        }
+      },
+      {
+        "size": 4,
+        "signed": false,
+        "name": "cell_a",
+        "c_type": "uint8_t",
+        "sim": {
+          "min": 0,
+          "max": 6,
+          "inc_min": 1,
+          "inc_max": 1,
+          "round": true
+        }
+      },
+      {
+        "size": 4,
+        "signed": false,
+        "name": "cell_b",
+        "c_type": "uint8_t",
+        "sim": {
+          "min": 0,
+          "max": 13,
+          "inc_min": 1,
+          "inc_max": 1,
+          "round": true
+        }
+      },
+      {
+        "size": 16,
+        "signed": false,
+        "parse": false
+      }
+    ],
+    "fields": [
+      {
+        "name": "Calypso/Bidir/State/BMSAlphaEmulatedCellData/{4}/Therms/{5}",
+        "unit": "C",
+        "values": [
+          1
+        ],
+        "doc": "Current emulated thermistor temperature"
+      },
+      {
+        "name": "Calypso/Bidir/State/BMSAlphaEmulatedCellData/{4}/Volts/{5}",
+        "unit": "V",
+        "values": [
+          2
+        ],
+        "doc": "Current emulated cell voltage"
+      },
+      {
+        "name": "Calypso/Bidir/State/BMSAlphaEmulatedCellData/{4}/Volts/{6}",
+        "unit": "V",
+        "values": [
+          3
+        ],
+        "doc": "Current emulated cell voltage"
+      }
+    ],
+    "key": "BMSBetaEmulatedCellData",
+    "bidir_mode": "broadcast",
+    "sim_freq": 500
+  },
+  {
+    "id": "0x457",
+    "desc": "Shepherd BMS Beta Emulated Cell Data",
+    "points": [
+      {
+        "size": 10,
+        "signed": false,
+        "name": "therm",
+        "c_type": "float",
+        "formatter": {
+          "key": "divide",
+          "arg": 10
+        },
+        "sim": {
+          "min": 20,
+          "max": 80,
+          "inc_min": 0.01,
+          "inc_max": 0.5,
+          "round": false
+        }
+      },
+      {
+        "size": 13,
+        "signed": false,
+        "name": "voltage_a",
+        "c_type": "float",
+        "formatter": {
+          "key": "divide",
+          "arg": 1000
+        },
+        "sim": {
+          "min": 2.5,
+          "max": 4.25,
+          "inc_min": 0.01,
+          "inc_max": 0.2,
+          "round": false
+        }
+      },
+      {
+        "size": 13,
+        "signed": false,
+        "name": "voltage_b",
+        "c_type": "float",
+        "formatter": {
+          "key": "divide",
+          "arg": 1000
+        },
+        "sim": {
+          "min": 2.5,
+          "max": 4.25,
+          "inc_min": 0.01,
+          "inc_max": 0.2
+        }
+      },
+      {
+        "size": 4,
+        "signed": false,
+        "name": "chip_id",
+        "c_type": "uint8_t",
+        "sim": {
+          "min": 0,
+          "max": 4,
+          "inc_min": 1,
+          "inc_max": 1,
+          "round": true
+        }
+      },
+      {
+        "size": 4,
+        "signed": false,
+        "name": "cell_a",
+        "c_type": "uint8_t",
+        "sim": {
+          "min": 0,
+          "max": 5,
+          "inc_min": 1,
+          "inc_max": 1,
+          "round": true
+        }
+      },
+      {
+        "size": 4,
+        "signed": false,
+        "name": "cell_b",
+        "c_type": "uint8_t",
+        "sim": {
+          "min": 0,
+          "max": 10,
+          "inc_min": 1,
+          "inc_max": 1,
+          "round": true
+        }
+      },
+      {
+        "size": 16,
+        "signed": false,
+        "parse": false
+      }
+    ],
+    "fields": [
+      {
+        "name": "Calypso/Bidir/State/BMSBetaEmulatedCellData/{4}/Therms/{5}",
+        "unit": "C",
+        "values": [
+          1
+        ],
+        "doc": "Current emulated thermistor temperature"
+      },
+      {
+        "name": "Calypso/Bidir/State/BMSBetaEmulatedCellData/{4}/Volts/{5}",
+        "unit": "V",
+        "values": [
+          2
+        ],
+        "doc": "Current emulated cell voltage"
+      },
+      {
+        "name": "Calypso/Bidir/State/BMSBetaEmulatedCellData/{4}/Volts/{6}",
+        "unit": "V",
+        "values": [
+          3
+        ],
+        "doc": "Current emulated cell voltage"
+      }
+    ],
+    "key": "BMSBetaEmulatedCellData",
+    "bidir_mode": "broadcast",
+    "sim_freq": 500
   }
 ]

--- a/can-messages/calypso_cmd.json
+++ b/can-messages/calypso_cmd.json
@@ -704,7 +704,7 @@
         "doc": "Current emulated cell voltage"
       }
     ],
-    "key": "BMSBetaEmulatedCellData",
+    "key": "BMSAlphaEmulatedCellData",
     "bidir_mode": "broadcast",
     "sim_freq": 500
   },

--- a/can-messages/calypso_cmd.json
+++ b/can-messages/calypso_cmd.json
@@ -590,7 +590,7 @@
         "c_type": "float",
         "formatter": {
           "key": "divide",
-          "arg": 10
+          "arg": 10.0
         },
         "sim": {
           "min": 20,
@@ -607,7 +607,7 @@
         "c_type": "float",
         "formatter": {
           "key": "divide",
-          "arg": 1000
+          "arg": 1000.0
         },
         "sim": {
           "min": 2.5,
@@ -624,7 +624,7 @@
         "c_type": "float",
         "formatter": {
           "key": "divide",
-          "arg": 1000
+          "arg": 1000.0
         },
         "sim": {
           "min": 2.5,
@@ -719,7 +719,7 @@
         "c_type": "float",
         "formatter": {
           "key": "divide",
-          "arg": 10
+          "arg": 10.0
         },
         "sim": {
           "min": 20,
@@ -736,7 +736,7 @@
         "c_type": "float",
         "formatter": {
           "key": "divide",
-          "arg": 1000
+          "arg": 1000.0
         },
         "sim": {
           "min": 2.5,
@@ -753,7 +753,7 @@
         "c_type": "float",
         "formatter": {
           "key": "divide",
-          "arg": 1000
+          "arg": 1000.0
         },
         "sim": {
           "min": 2.5,

--- a/can-messages/calypso_cmd.json
+++ b/can-messages/calypso_cmd.json
@@ -580,7 +580,7 @@
     "bidir_mode": "oneshot"
   },
   {
-    "id": "0x456",
+    "id": "0x451",
     "desc": "Shepherd BMS Alpha Emulated Cell Data",
     "points": [
       {
@@ -709,7 +709,7 @@
     "sim_freq": 500
   },
   {
-    "id": "0x457",
+    "id": "0x452",
     "desc": "Shepherd BMS Beta Emulated Cell Data",
     "points": [
       {


### PR DESCRIPTION
## Changes

Added BMS HIL Calypso test-mode messages for emulated Alpha and Beta cell voltage and temperature data.